### PR TITLE
Add kitspace.yml

### DIFF
--- a/kitspace.yml
+++ b/kitspace.yml
@@ -1,0 +1,8 @@
+site: https://watchy.sqfmi.com/
+summary: A fully open source & customizable E-Ink watch
+bom: WatchyBOM.csv
+gerbers: GERBER/
+color: black
+eda:
+  type: kicad
+  pcb: Watchy.kicad_pcb


### PR DESCRIPTION
Hi, thought this would be a nice project to put up a [kitspace.org](https://kitspace.org) page for. I added the required kitspace.yml manifest file. 

[Here is a preview](http://try-watchy.preview.kitspace.org/boards/github.com/kitspace-forks/watchy-hardware/) of what it would look like. If you are happy to add it, just merge this in. The page will be put up and keep updating with your repo in the future (every 3 hours or so). 

The BOM could be improved to make it purchaseable and get the "buy parts" links on Kitspace ot show up. I'd be happy to give you access to a hosted version of our [bom-builder](https://kitspace.org/bom-builder) ([source-code](https://github.com/kitspace/bom-builder)) if you think it would help you do that. 